### PR TITLE
fix: production useStaticQuery with siteMetaData

### DIFF
--- a/src/babel-plugin-remove-graphql-queries.js
+++ b/src/babel-plugin-remove-graphql-queries.js
@@ -268,6 +268,9 @@ export default function({ types: t }) {
               path2.replaceWith(
                 getGraphqlExpr(t, this.queryHash, this.query)
               )
+              
+              path2.replaceWith(t.memberExpression(identifier, t.identifier(`data`)))
+
 
               // Add import
               const importDefaultSpecifier = t.importDefaultSpecifier(


### PR DESCRIPTION
Hello, 

There's an issure when using `gatsby-source-prismic-graphql` and that is that useStaticQuery is broken by this plugin when querying siteMetaData.

This PR fixes the issue on the sample project: https://github.com/MarcMcIntosh/use-static-query-gatsby-prismic-source-graphql-bug

Best,
Marc